### PR TITLE
feat: 회원가입/로그인 구현 및 엔티티 개선

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">

--- a/src/main/java/success/planfit/controller/AuthorizationController.java
+++ b/src/main/java/success/planfit/controller/AuthorizationController.java
@@ -6,10 +6,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import success.planfit.controller.utils.ControllerUtil;
+import success.planfit.domain.user.User;
 import success.planfit.dto.request.PlanFitUserSignInRequestDto;
 import success.planfit.dto.request.PlanFitUserSignUpRequestDto;
 import success.planfit.dto.response.TokenResponseDto;
 import success.planfit.service.AuthorizationService;
+
+import java.security.Principal;
 
 /**
  * 회원가입/로그인과 관련된 API를 처리하는 컨트롤러
@@ -20,6 +24,7 @@ import success.planfit.service.AuthorizationService;
 public class AuthorizationController {
 
     private final AuthorizationService authorizationService;
+    private final ControllerUtil util;
 
     @PostMapping("/authorization")
     public ResponseEntity<TokenResponseDto> planFitSignUp(@RequestBody PlanFitUserSignUpRequestDto requestDto) {
@@ -81,5 +86,25 @@ public class AuthorizationController {
         TokenResponseDto responseDto = authorizationService.kakaoSignUpOrSignIn(kakaoAccessToken);
 
         return ResponseEntity.ok(responseDto);
+    }
+
+    @DeleteMapping("/user/logout")
+    public ResponseEntity<Void> logout(Principal principal) {
+        log.info("UserController.logout() called");
+
+        User user = util.findUserByPrincipal(principal);
+        authorizationService.invalidateRefreshToken(user);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/user/withdraw")
+    public ResponseEntity<Void> withdraw(Principal principal) {
+        log.info("UserController.withdraw() called");
+
+        User user = util.findUserByPrincipal(principal);
+        authorizationService.deleteUser(user);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/success/planfit/controller/AuthorizationController.java
+++ b/src/main/java/success/planfit/controller/AuthorizationController.java
@@ -1,5 +1,6 @@
 package success.planfit.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -7,9 +8,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import success.planfit.controller.utils.ControllerUtil;
-import success.planfit.domain.user.User;
 import success.planfit.dto.request.PlanFitUserSignInRequestDto;
 import success.planfit.dto.request.PlanFitUserSignUpRequestDto;
+import success.planfit.dto.response.AccessTokenResponseDto;
 import success.planfit.dto.response.TokenResponseDto;
 import success.planfit.service.AuthorizationService;
 
@@ -92,8 +93,8 @@ public class AuthorizationController {
     public ResponseEntity<Void> logout(Principal principal) {
         log.info("UserController.logout() called");
 
-        User user = util.findUserByPrincipal(principal);
-        authorizationService.invalidateRefreshToken(user);
+        Long userId = util.findUserIdByPrincipal(principal);
+        authorizationService.invalidateRefreshToken(userId);
 
         return ResponseEntity.ok().build();
     }
@@ -102,9 +103,19 @@ public class AuthorizationController {
     public ResponseEntity<Void> withdraw(Principal principal) {
         log.info("UserController.withdraw() called");
 
-        User user = util.findUserByPrincipal(principal);
-        authorizationService.deleteUser(user);
+        Long userId = util.findUserIdByPrincipal(principal);
+        authorizationService.deleteUser(userId);
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/authorization/reissue")
+    public ResponseEntity<AccessTokenResponseDto> reissueAccessToken(HttpServletRequest request) {
+        log.info("UserController.reissueAccessToken() called");
+
+        String refreshToken = util.getTokenFromServletRequest(request);
+        AccessTokenResponseDto responseDto = authorizationService.reissueAccessToken(refreshToken);
+
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/success/planfit/controller/AuthorizationController.java
+++ b/src/main/java/success/planfit/controller/AuthorizationController.java
@@ -17,12 +17,11 @@ import success.planfit.service.AuthorizationService;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/authorization")
 public class AuthorizationController {
 
     private final AuthorizationService authorizationService;
 
-    @PostMapping
+    @PostMapping("/authorization")
     public ResponseEntity<TokenResponseDto> planFitSignUp(@RequestBody PlanFitUserSignUpRequestDto requestDto) {
         log.info("UserController.planFitSignUp() called");
 
@@ -31,7 +30,7 @@ public class AuthorizationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
-    @GetMapping
+    @GetMapping("/authorization")
     public ResponseEntity<TokenResponseDto> planFitSignIn(@RequestBody PlanFitUserSignInRequestDto requestDto) {
         log.info("UserController.planFitSignIn() called");
 
@@ -40,7 +39,7 @@ public class AuthorizationController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @GetMapping("/google")
+    @GetMapping("/authorization/google")
     public ResponseEntity<Void> googleRedirect() {
         log.info("UserController.googleRedirect() called");
 
@@ -52,7 +51,7 @@ public class AuthorizationController {
     /**
      * 사용자가 구글 로그인을 마치면, 구글 측의 리다이렉트로 연결될 컨트롤러
      */
-    @GetMapping("/google/callback")
+    @GetMapping("/authorization/google/callback")
     public ResponseEntity<TokenResponseDto> googleAuthorization(@RequestParam(name = "code") String code) {
         log.info("UserController.googleCallback() called");
 
@@ -62,7 +61,7 @@ public class AuthorizationController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @GetMapping("/kakao")
+    @GetMapping("/authorization/kakao")
     public ResponseEntity<Void> kakaoRedirect() {
         log.info("UserController.kakaoRedirect() called");
 
@@ -74,7 +73,7 @@ public class AuthorizationController {
     /**
      * 사용자가 카카오 로그인을 마치면, 카카오 측의 리다이렉트로 연결될 컨트롤러
      */
-    @GetMapping("/kakao/callback")
+    @GetMapping("/authorization/kakao/callback")
     public ResponseEntity<TokenResponseDto> kakaoAuthorization(@RequestParam(name = "code") String code) {
         log.info("UserController.kakaoAuthorization() called");
 

--- a/src/main/java/success/planfit/controller/AuthorizationController.java
+++ b/src/main/java/success/planfit/controller/AuthorizationController.java
@@ -1,0 +1,86 @@
+package success.planfit.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import success.planfit.dto.request.PlanFitUserSignInRequestDto;
+import success.planfit.dto.request.PlanFitUserSignUpRequestDto;
+import success.planfit.dto.response.TokenResponseDto;
+import success.planfit.service.AuthorizationService;
+
+/**
+ * 회원가입/로그인과 관련된 API를 처리하는 컨트롤러
+ */
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/authorization")
+public class AuthorizationController {
+
+    private final AuthorizationService authorizationService;
+
+    @PostMapping
+    public ResponseEntity<TokenResponseDto> planFitSignUp(@RequestBody PlanFitUserSignUpRequestDto requestDto) {
+        log.info("UserController.planFitSignUp() called");
+
+        TokenResponseDto responseDto = authorizationService.planFitSignUp(requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<TokenResponseDto> planFitSignIn(@RequestBody PlanFitUserSignInRequestDto requestDto) {
+        log.info("UserController.planFitSignIn() called");
+
+        TokenResponseDto responseDto = authorizationService.planFitSignIn(requestDto);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/google")
+    public ResponseEntity<Void> googleRedirect() {
+        log.info("UserController.googleRedirect() called");
+
+        return ResponseEntity.status(HttpStatus.SEE_OTHER)
+                .header(HttpHeaders.LOCATION, authorizationService.getGoogleRedirectUrl())
+                .build();
+    }
+
+    /**
+     * 사용자가 구글 로그인을 마치면, 구글 측의 리다이렉트로 연결될 컨트롤러
+     */
+    @GetMapping("/google/callback")
+    public ResponseEntity<TokenResponseDto> googleAuthorization(@RequestParam(name = "code") String code) {
+        log.info("UserController.googleCallback() called");
+
+        String googleAccessToken = authorizationService.getGoogleAccessToken(code);
+        TokenResponseDto responseDto = authorizationService.googleSignUpOrSignIn(googleAccessToken);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/kakao")
+    public ResponseEntity<Void> kakaoRedirect() {
+        log.info("UserController.kakaoRedirect() called");
+
+        return ResponseEntity.status(HttpStatus.SEE_OTHER)
+                .header(HttpHeaders.LOCATION, authorizationService.getKakaoRedirectUrl())
+                .build();
+    }
+
+    /**
+     * 사용자가 카카오 로그인을 마치면, 카카오 측의 리다이렉트로 연결될 컨트롤러
+     */
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<TokenResponseDto> kakaoAuthorization(@RequestParam(name = "code") String code) {
+        log.info("UserController.kakaoAuthorization() called");
+
+        String kakaoAccessToken = authorizationService.getKakaoAccessToken(code);
+        TokenResponseDto responseDto = authorizationService.kakaoSignUpOrSignIn(kakaoAccessToken);
+
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/success/planfit/controller/utils/ControllerUtil.java
+++ b/src/main/java/success/planfit/controller/utils/ControllerUtil.java
@@ -1,0 +1,25 @@
+package success.planfit.controller.utils;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import success.planfit.domain.user.User;
+import success.planfit.service.UserService;
+
+import java.security.Principal;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ControllerUtil {
+
+    private final UserService userService;
+
+    public User findUserByPrincipal(Principal principal) {
+        log.info("ControllerUtil.findUserByPrincipal()");
+
+        long userId = Long.parseLong(principal.getName());
+
+        return userService.findById(userId);
+    }
+}

--- a/src/main/java/success/planfit/controller/utils/ControllerUtil.java
+++ b/src/main/java/success/planfit/controller/utils/ControllerUtil.java
@@ -1,9 +1,10 @@
 package success.planfit.controller.utils;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import success.planfit.domain.user.User;
+import success.planfit.jwt.TokenProvider;
 import success.planfit.service.UserService;
 
 import java.security.Principal;
@@ -14,12 +15,17 @@ import java.security.Principal;
 public class ControllerUtil {
 
     private final UserService userService;
+    private final TokenProvider tokenProvider;
 
-    public User findUserByPrincipal(Principal principal) {
+    public Long findUserIdByPrincipal(Principal principal) {
         log.info("ControllerUtil.findUserByPrincipal()");
 
-        long userId = Long.parseLong(principal.getName());
+        return Long.parseLong(principal.getName());
+    }
 
-        return userService.findById(userId);
+    public String getTokenFromServletRequest(HttpServletRequest request) {
+        log.info("ControllerUtil.getTokenFromServletRequest()");
+
+        return tokenProvider.resolveToken(request);
     }
 }

--- a/src/main/java/success/planfit/domain/RefreshToken.java
+++ b/src/main/java/success/planfit/domain/RefreshToken.java
@@ -1,29 +1,27 @@
 package success.planfit.domain;
 
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import success.planfit.domain.user.User;
 
 @Getter
 @NoArgsConstructor
 @Entity
 public class RefreshToken {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @JoinColumn (nullable = false)
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
-
     private String tokenValue;
 
     @Builder
-    private RefreshToken(User user, String tokenValue) {
-        this.user = user;
+    private RefreshToken(String tokenValue) {
         this.tokenValue = tokenValue;
     }
 }

--- a/src/main/java/success/planfit/domain/RefreshToken.java
+++ b/src/main/java/success/planfit/domain/RefreshToken.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
@@ -18,6 +19,7 @@ public class RefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     private String tokenValue;
 
     @Builder

--- a/src/main/java/success/planfit/domain/user/GoogleUser.java
+++ b/src/main/java/success/planfit/domain/user/GoogleUser.java
@@ -4,8 +4,9 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import success.planfit.domain.RefreshToken;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 
 @Getter
@@ -20,8 +21,8 @@ public class GoogleUser extends User {
     private String googleIdentifier;
 
     @Builder
-    private GoogleUser(String name, String phoneNumber, LocalDateTime birthOfDate, IdentityType identity, String email, String profileUrl, String googleIdentifier) {
-        super(name, phoneNumber, birthOfDate, identity, email, profileUrl);
+    private GoogleUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, String googleIdentifier, RefreshToken refreshToken) {
+        super(name, phoneNumber, birthOfDate, identity, email, profileUrl, refreshToken);
         this.googleIdentifier = googleIdentifier;
     }
 }

--- a/src/main/java/success/planfit/domain/user/GoogleUser.java
+++ b/src/main/java/success/planfit/domain/user/GoogleUser.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import success.planfit.domain.RefreshToken;
 
 import java.time.LocalDate;
 
@@ -21,8 +20,8 @@ public class GoogleUser extends User {
     private String googleIdentifier;
 
     @Builder
-    private GoogleUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, String googleIdentifier, RefreshToken refreshToken) {
-        super(name, phoneNumber, birthOfDate, identity, email, profileUrl, refreshToken);
+    private GoogleUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, String googleIdentifier) {
+        super(name, phoneNumber, birthOfDate, identity, email, profileUrl);
         this.googleIdentifier = googleIdentifier;
     }
 }

--- a/src/main/java/success/planfit/domain/user/KakaoUser.java
+++ b/src/main/java/success/planfit/domain/user/KakaoUser.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import success.planfit.domain.RefreshToken;
 
 import java.time.LocalDate;
 
@@ -22,8 +21,8 @@ public class KakaoUser extends User {
     private Long kakaoIdentifier;
 
     @Builder
-    private KakaoUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, Long kakaoIdentifier, RefreshToken refreshToken) {
-        super(name, phoneNumber, birthOfDate, identity, email, profileUrl, refreshToken);
+    private KakaoUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, Long kakaoIdentifier) {
+        super(name, phoneNumber, birthOfDate, identity, email, profileUrl);
         this.kakaoIdentifier = kakaoIdentifier;
     }
 }

--- a/src/main/java/success/planfit/domain/user/KakaoUser.java
+++ b/src/main/java/success/planfit/domain/user/KakaoUser.java
@@ -5,8 +5,9 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import success.planfit.domain.RefreshToken;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
@@ -21,8 +22,8 @@ public class KakaoUser extends User {
     private Long kakaoIdentifier;
 
     @Builder
-    private KakaoUser(String name, String phoneNumber, LocalDateTime birthOfDate, IdentityType identity, String email, String profileUrl, Long kakaoIdentifier) {
-        super(name, phoneNumber, birthOfDate, identity, email, profileUrl);
+    private KakaoUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, Long kakaoIdentifier, RefreshToken refreshToken) {
+        super(name, phoneNumber, birthOfDate, identity, email, profileUrl, refreshToken);
         this.kakaoIdentifier = kakaoIdentifier;
     }
 }

--- a/src/main/java/success/planfit/domain/user/PlanfitUser.java
+++ b/src/main/java/success/planfit/domain/user/PlanfitUser.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
@@ -24,7 +24,7 @@ public class PlanfitUser extends User {
     private String password;
 
     @Builder
-    private PlanfitUser(String name, String phoneNumber, LocalDateTime birthOfDate, IdentityType identity, String email, String profileUrl, String loginId, String password) {
+    private PlanfitUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, String loginId, String password) {
         super(name, phoneNumber, birthOfDate, identity, email, profileUrl);
         this.loginId = loginId;
         this.password = password;

--- a/src/main/java/success/planfit/domain/user/PlanfitUser.java
+++ b/src/main/java/success/planfit/domain/user/PlanfitUser.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import success.planfit.domain.RefreshToken;
 
 import java.time.LocalDate;
 
@@ -25,8 +24,8 @@ public class PlanfitUser extends User {
     private String password;
 
     @Builder
-    private PlanfitUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, String loginId, String password, RefreshToken refreshToken) {
-        super(name, phoneNumber, birthOfDate, identity, email, profileUrl, refreshToken);
+    private PlanfitUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, String loginId, String password) {
+        super(name, phoneNumber, birthOfDate, identity, email, profileUrl);
         this.loginId = loginId;
         this.password = password;
     }

--- a/src/main/java/success/planfit/domain/user/PlanfitUser.java
+++ b/src/main/java/success/planfit/domain/user/PlanfitUser.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import success.planfit.domain.RefreshToken;
 
 import java.time.LocalDate;
 
@@ -24,8 +25,8 @@ public class PlanfitUser extends User {
     private String password;
 
     @Builder
-    private PlanfitUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, String loginId, String password) {
-        super(name, phoneNumber, birthOfDate, identity, email, profileUrl);
+    private PlanfitUser(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, String loginId, String password, RefreshToken refreshToken) {
+        super(name, phoneNumber, birthOfDate, identity, email, profileUrl, refreshToken);
         this.loginId = loginId;
         this.password = password;
     }

--- a/src/main/java/success/planfit/domain/user/User.java
+++ b/src/main/java/success/planfit/domain/user/User.java
@@ -4,7 +4,6 @@ package success.planfit.domain.user;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import success.planfit.domain.RefreshToken;
 
 import java.time.LocalDate;
@@ -23,7 +22,6 @@ public abstract class User {
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn
-    @Setter
     private RefreshToken refreshToken;
 
     @Column(nullable = false)
@@ -31,11 +29,9 @@ public abstract class User {
 
     private String phoneNumber;
 
-    @Column(nullable = false)
     private LocalDate birthOfDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private IdentityType identity;
 
     @Column(nullable = false)
@@ -43,14 +39,14 @@ public abstract class User {
 
     private String profileUrl;
 
-    protected User(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, RefreshToken refreshToken){
+    protected User(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl){
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.birthOfDate = birthOfDate;
         this.identity = identity;
         this.email = email;
         this.profileUrl = profileUrl;
-        this.refreshToken = refreshToken;
+        this.refreshToken = RefreshToken.builder().build(); // 빈 값인 RefreshToken 엔티티 생성
     }
 
 }

--- a/src/main/java/success/planfit/domain/user/User.java
+++ b/src/main/java/success/planfit/domain/user/User.java
@@ -4,6 +4,8 @@ package success.planfit.domain.user;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import success.planfit.domain.RefreshToken;
 
 import java.time.LocalDate;
 
@@ -18,6 +20,11 @@ public abstract class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn
+    @Setter
+    private RefreshToken refreshToken;
 
     @Column(nullable = false)
     private String name;
@@ -36,13 +43,14 @@ public abstract class User {
 
     private String profileUrl;
 
-    protected User(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl){
+    protected User(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl, RefreshToken refreshToken){
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.birthOfDate = birthOfDate;
         this.identity = identity;
         this.email = email;
         this.profileUrl = profileUrl;
+        this.refreshToken = refreshToken;
     }
 
 }

--- a/src/main/java/success/planfit/domain/user/User.java
+++ b/src/main/java/success/planfit/domain/user/User.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 
 @Getter
@@ -25,7 +25,7 @@ public abstract class User {
     private String phoneNumber;
 
     @Column(nullable = false)
-    private LocalDateTime birthOfDate;
+    private LocalDate birthOfDate;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -36,7 +36,7 @@ public abstract class User {
 
     private String profileUrl;
 
-    protected User(String name, String phoneNumber, LocalDateTime birthOfDate, IdentityType identity, String email, String profileUrl){
+    protected User(String name, String phoneNumber, LocalDate birthOfDate, IdentityType identity, String email, String profileUrl){
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.birthOfDate = birthOfDate;

--- a/src/main/java/success/planfit/domain/user/User.java
+++ b/src/main/java/success/planfit/domain/user/User.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn(name="authorized_by", discriminatorType = DiscriminatorType.STRING)
+@DiscriminatorColumn(discriminatorType = DiscriminatorType.STRING)
 public abstract class User {
 
     @Id

--- a/src/main/java/success/planfit/dto/google/GoogleAccessTokenDto.java
+++ b/src/main/java/success/planfit/dto/google/GoogleAccessTokenDto.java
@@ -1,0 +1,15 @@
+package success.planfit.dto.google;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GoogleAccessTokenDto {
+
+    @SerializedName("access_token")
+    private String accessToken;
+}

--- a/src/main/java/success/planfit/dto/google/GoogleUserInfoDto.java
+++ b/src/main/java/success/planfit/dto/google/GoogleUserInfoDto.java
@@ -1,0 +1,22 @@
+package success.planfit.dto.google;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GoogleUserInfoDto {
+    private String id;
+    private String email;
+    @SerializedName("verified_email")
+    private Boolean verifiedEmail;
+    private String name;
+    @SerializedName("given_name")
+    private String givenName;
+    @SerializedName("family_name")
+    private String familyName;
+    @SerializedName("picture")
+    private String pictureUrl;
+    private String locale;
+}

--- a/src/main/java/success/planfit/dto/kakao/KaKaoUserInfoDto.java
+++ b/src/main/java/success/planfit/dto/kakao/KaKaoUserInfoDto.java
@@ -1,0 +1,73 @@
+package success.planfit.dto.kakao;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 참고 문서: <a href="https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info">...</a>
+ */
+@Getter
+@AllArgsConstructor
+public class KaKaoUserInfoDto {
+
+    private Long id;
+
+    @SerializedName("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @AllArgsConstructor
+    static class KakaoAccount {
+
+        @SerializedName("profile_nickname_needs_agreement")
+        private Boolean profileNicknameNeedsAgreement;
+        @SerializedName("profile_image_needs_agreement")
+        private Boolean profileImageNeedsAgreement;
+        private Profile profile;
+
+        @SerializedName("email_needs_agreement")
+        private Boolean emailNeedsAgreement;
+        @SerializedName("is_email_valid")
+        private Boolean isEmailValid;
+        @SerializedName("is_email_verified")
+        private Boolean getIsEmailVerified;
+        private String email;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class Profile {
+
+        @SerializedName("nickname")
+        private String name;
+        @SerializedName("thumbnail_image_url")
+        private String thumbnailImageUrl;
+        @SerializedName("profile_image_url")
+        private String profileImageUrl;
+        @SerializedName("is_default_image")
+        private Boolean isDefaultImage;
+        @SerializedName("is_default_nickname")
+        private Boolean isDefaultNickname;
+    }
+
+    public String getEmail() {
+        return this.kakaoAccount.email;
+    }
+
+    public String getName() {
+        return this.kakaoAccount.profile.name;
+    }
+
+    public String getProfileUrl() {
+        return this.kakaoAccount.profile.profileImageUrl;
+    }
+
+    public Boolean isValidatedEmail() {
+        if (kakaoAccount.isEmailValid == null || kakaoAccount.getIsEmailVerified == null) {
+            return false;
+        }
+
+        return kakaoAccount.isEmailValid && kakaoAccount.getIsEmailVerified;
+    }
+}

--- a/src/main/java/success/planfit/dto/kakao/KakaoAccessTokenDto.java
+++ b/src/main/java/success/planfit/dto/kakao/KakaoAccessTokenDto.java
@@ -1,0 +1,12 @@
+package success.planfit.dto.kakao;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+
+@Getter
+public class KakaoAccessTokenDto {
+
+    @SerializedName("access_token")
+    private String accessToken;
+
+}

--- a/src/main/java/success/planfit/dto/request/PlanFitUserSignInRequestDto.java
+++ b/src/main/java/success/planfit/dto/request/PlanFitUserSignInRequestDto.java
@@ -1,0 +1,10 @@
+package success.planfit.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class PlanFitUserSignInRequestDto {
+
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/success/planfit/dto/request/PlanFitUserSignUpRequestDto.java
+++ b/src/main/java/success/planfit/dto/request/PlanFitUserSignUpRequestDto.java
@@ -1,0 +1,35 @@
+package success.planfit.dto.request;
+
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+import success.planfit.domain.user.IdentityType;
+import success.planfit.domain.user.PlanfitUser;
+
+import java.time.LocalDate;
+
+@Getter
+public class PlanFitUserSignUpRequestDto {
+
+    private String name;
+    private String loginId;
+    private String password;
+    private String phoneNumber;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate birthOfDate;
+    private IdentityType identity;
+    private String email;
+    private String profileUrl;
+
+    public PlanfitUser toEntity() {
+        return PlanfitUser.builder()
+                .name(name)
+                .loginId(loginId)
+                .password(password)
+                .phoneNumber(phoneNumber)
+                .birthOfDate(birthOfDate)
+                .identity(identity)
+                .email(email)
+                .profileUrl(profileUrl)
+                .build();
+    }
+}

--- a/src/main/java/success/planfit/dto/response/AccessTokenResponseDto.java
+++ b/src/main/java/success/planfit/dto/response/AccessTokenResponseDto.java
@@ -1,0 +1,8 @@
+package success.planfit.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AccessTokenResponseDto(String accessToken) {
+
+}

--- a/src/main/java/success/planfit/dto/response/TokenResponseDto.java
+++ b/src/main/java/success/planfit/dto/response/TokenResponseDto.java
@@ -1,0 +1,8 @@
+package success.planfit.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponseDto(String accessToken, String refreshToken) {
+
+}

--- a/src/main/java/success/planfit/jwt/JwtFilter.java
+++ b/src/main/java/success/planfit/jwt/JwtFilter.java
@@ -1,0 +1,33 @@
+package success.planfit.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        String token = tokenProvider.resolveToken((HttpServletRequest) request);
+
+        // 토큰이 적절하다면 SecurityContextHolder 에 사용자의 권한 정보를 추가
+        if (StringUtils.hasText(token) && tokenProvider.validateToken(token, TokenType.ACCESS)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/success/planfit/jwt/SecurityConfig.java
+++ b/src/main/java/success/planfit/jwt/SecurityConfig.java
@@ -1,0 +1,58 @@
+package success.planfit.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/authorization/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .cors(cors -> cors.configurationSource(configurationSource()))
+                .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource configurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Access-Control-Allow-Credentials", "Authorization", "Set-Cookie"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/success/planfit/jwt/TokenProvider.java
+++ b/src/main/java/success/planfit/jwt/TokenProvider.java
@@ -96,12 +96,12 @@ public class TokenProvider {
     /**
      * 문자열 토큰을 Claims 로 변환하는 메서드
      */
-    public Claims parseClaims(String accessToken) {
+    public Claims parseClaims(String token) {
         try {
             return Jwts.parserBuilder()
                     .setSigningKey(key)
                     .build()
-                    .parseClaimsJws(accessToken)
+                    .parseClaimsJws(token)
                     .getBody();
         } catch (ExpiredJwtException e) {
             return e.getClaims();

--- a/src/main/java/success/planfit/jwt/TokenProvider.java
+++ b/src/main/java/success/planfit/jwt/TokenProvider.java
@@ -91,7 +91,6 @@ public class TokenProvider {
                     .parseClaimsJws(token);
             return hasProperType(token, tokenType);
         } catch (UnsupportedJwtException | ExpiredJwtException | IllegalArgumentException | MalformedJwtException e) {
-            e.printStackTrace();
             return false;
         }
     }

--- a/src/main/java/success/planfit/jwt/TokenProvider.java
+++ b/src/main/java/success/planfit/jwt/TokenProvider.java
@@ -8,12 +8,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import success.planfit.domain.user.User;
 
 import java.security.Key;
 import java.util.Date;
+import java.util.List;
 
 @Component
 public class TokenProvider {
@@ -58,7 +60,7 @@ public class TokenProvider {
     public Authentication getAuthentication(String accessToken) {
         Claims claims = parseClaims(accessToken);
 
-        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(claims.getSubject(), "");
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(claims.getSubject(), "", List.of(new SimpleGrantedAuthority("ROLE_USER")));
         authentication.setDetails(claims);
 
         return authentication;
@@ -89,6 +91,7 @@ public class TokenProvider {
                     .parseClaimsJws(token);
             return hasProperType(token, tokenType);
         } catch (UnsupportedJwtException | ExpiredJwtException | IllegalArgumentException | MalformedJwtException e) {
+            e.printStackTrace();
             return false;
         }
     }

--- a/src/main/java/success/planfit/jwt/TokenProvider.java
+++ b/src/main/java/success/planfit/jwt/TokenProvider.java
@@ -1,0 +1,122 @@
+package success.planfit.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import success.planfit.domain.user.User;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class TokenProvider {
+
+    private static final String TOKEN_TYPE_CLAIM = "PlanFit/TokenType";
+    private static final String BEARER = "Bearer ";
+    private static final String AUTHORIZATION = "Authorization";
+
+    private final long validityTime;
+    private final Key key;
+
+    public TokenProvider(@Value("${keys.jwt.secret}") String jwtSecret, @Value("${keys.jwt.access-token-validity-in-milliseconds}") long validityTime) {
+        byte[] keyBytes = Decoders.BASE64.decode(jwtSecret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.validityTime = validityTime;
+    }
+
+    public String createToken(User user, TokenType tokenType) {
+        // 토큰의 타입에 맞게 만료 시간을 지정함(리프레쉬 토큰의 지속시간을 24배 길게 설정함)
+        Date accessTokenExpiredTime;
+        switch (tokenType) {
+            case ACCESS -> {
+                accessTokenExpiredTime = new Date(new Date().getTime() + validityTime);
+            }
+            case REFRESH -> {
+                accessTokenExpiredTime = new Date(new Date().getTime() + (validityTime * 24));
+            }
+            case null, default ->  {
+                throw new IllegalArgumentException("토큰 생성 실패: 부적절한 TokenType 입니다.");
+            }
+        }
+
+        return Jwts.builder()
+                .setSubject(user.getId().toString())
+                .claim(TOKEN_TYPE_CLAIM, tokenType)
+                .setExpiration(accessTokenExpiredTime)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(claims.getSubject(), "");
+        authentication.setDetails(claims);
+
+        return authentication;
+    }
+
+    /**
+     * 토큰 앞의 "Bearer "를 제거하는 메서드
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER)) {
+            return bearerToken.substring(7);
+        }
+
+        // 토큰이 Bearer 형식이 아닐 경우, 부적절한 토큰이므로 null 을 반환함
+        return null;
+    }
+
+    /**
+     * 토큰의 유효성을 검증하는 메서드
+     */
+    public boolean validateToken(String token, TokenType tokenType) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return hasProperType(token, tokenType);
+        } catch (UnsupportedJwtException | ExpiredJwtException | IllegalArgumentException | MalformedJwtException e) {
+            return false;
+        }
+    }
+
+    /**
+     * 문자열 토큰을 Claims 로 변환하는 메서드
+     */
+    public Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        } catch (SignatureException e) {
+            throw new IllegalArgumentException("토큰 복호화 실패: 부적절한 토큰입니다.");
+        }
+    }
+
+    /**
+     * 토큰의 타입이 파라미터로 넘긴 타입과 일치하는지를 반환하는 메서드
+     */
+    private boolean hasProperType(String token, TokenType tokenType) {
+        Claims claims = parseClaims(token);
+        String tokenTypeClaim = (String) claims.get(TOKEN_TYPE_CLAIM);
+
+        return tokenType == TokenType.valueOf(tokenTypeClaim);
+    }
+}

--- a/src/main/java/success/planfit/jwt/TokenType.java
+++ b/src/main/java/success/planfit/jwt/TokenType.java
@@ -1,0 +1,5 @@
+package success.planfit.jwt;
+
+public enum TokenType {
+    ACCESS, REFRESH
+}

--- a/src/main/java/success/planfit/repository/UserRepository.java
+++ b/src/main/java/success/planfit/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package success.planfit.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import success.planfit.domain.user.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Query("select u from PlanfitUser u where u.loginId = :loginId and u.password = :password")
+    Optional<User> findByLoginIdAndPassword(@Param("loginId") String loginId, @Param("password") String password);
+
+    @Query("select u from GoogleUser u where u.googleIdentifier = :identifier")
+    Optional<User> findByGoogleIdentifier(@Param("identifier") String identifier);
+
+    @Query("select u from KakaoUser u where u.kakaoIdentifier = :identifier")
+    Optional<User> findByKakaoIdentifier(@Param("identifier") Long identifier);
+}

--- a/src/main/java/success/planfit/service/AuthorizationService.java
+++ b/src/main/java/success/planfit/service/AuthorizationService.java
@@ -1,0 +1,309 @@
+package success.planfit.service;
+
+import com.google.gson.Gson;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import success.planfit.domain.user.GoogleUser;
+import success.planfit.domain.user.KakaoUser;
+import success.planfit.domain.user.PlanfitUser;
+import success.planfit.domain.user.User;
+import success.planfit.dto.google.GoogleAccessTokenDto;
+import success.planfit.dto.google.GoogleUserInfoDto;
+import success.planfit.dto.kakao.KaKaoUserInfoDto;
+import success.planfit.dto.kakao.KakaoAccessTokenDto;
+import success.planfit.dto.request.PlanFitUserSignInRequestDto;
+import success.planfit.dto.request.PlanFitUserSignUpRequestDto;
+import success.planfit.dto.response.TokenResponseDto;
+import success.planfit.jwt.TokenProvider;
+import success.planfit.jwt.TokenType;
+import success.planfit.repository.UserRepository;
+
+import java.net.URI;
+import java.util.Map;
+
+@Service
+@Transactional
+@Slf4j
+public class AuthorizationService {
+
+    // 의존성 관련 필드
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    // 구글 로그인 관련 필드
+    private final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+    private final String GOOGLE_CLIENT_ID;
+    private final String GOOGLE_CLIENT_SECRET;
+    private final String GOOGLE_REDIRECT_URI;
+
+    // 카카오 로그인 관련 필드
+    private final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private final String KAKAO_CLIENT_ID;
+    private final String KAKAO_CLIENT_SECRET;
+    private final String KAKAO_REDIRECT_URL;
+
+    public AuthorizationService(
+            UserRepository userRepository,
+            TokenProvider tokenProvider,
+            @Value("${keys.google.client-id}") String googleClientId,
+            @Value("${keys.google.client-secret}") String googleClientSecret,
+            @Value("${keys.google.redirect-uri}") String googleRedirectUri,
+            @Value("${keys.kakao.rest-api-key}") String kakaoClientId,
+            @Value("${keys.kakao.client-secret}") String kakaoClientSecret,
+            @Value("${keys.kakao.redirect-uri}") String kakaoRedirectUri
+    ) {
+        this.userRepository = userRepository;
+        this.tokenProvider = tokenProvider;
+
+        this.GOOGLE_CLIENT_ID = googleClientId;
+        this.GOOGLE_CLIENT_SECRET = googleClientSecret;
+        this.GOOGLE_REDIRECT_URI = googleRedirectUri;
+
+        this.KAKAO_CLIENT_ID = kakaoClientId;
+        this.KAKAO_CLIENT_SECRET = kakaoClientSecret;
+        this.KAKAO_REDIRECT_URL = kakaoRedirectUri;
+    }
+
+    public TokenResponseDto planFitSignUp(PlanFitUserSignUpRequestDto requestDto) {
+        log.info("AuthorizationService.planFitSignUp() called");
+
+        // User 엔티티를 영속화
+        PlanfitUser user = requestDto.toEntity();
+        userRepository.save(user);
+
+        // JWT 토큰을 발급 및 RefreshToken 엔티티 값 갱신
+        String accessTokenValue = tokenProvider.createToken(user, TokenType.ACCESS);
+        String refreshTokenValue = tokenProvider.createToken(user, TokenType.REFRESH);
+        user.getRefreshToken().setTokenValue(refreshTokenValue);
+
+        // TokenResponseDto를 반환
+        return TokenResponseDto.builder()
+                .accessToken(accessTokenValue)
+                .refreshToken(refreshTokenValue)
+                .build();
+    }
+
+    public TokenResponseDto planFitSignIn(PlanFitUserSignInRequestDto requestDto) {
+        log.info("AuthorizationService.planFitSignIn() called");
+
+        // DTO로부터 값을 추출
+        String loginId = requestDto.getLoginId();
+        String password = requestDto.getPassword();
+
+        // 아이디와 비밀번호를 통해 유저 조회
+        User user = userRepository.findByLoginIdAndPassword(loginId, password)
+                .orElseThrow(() -> new IllegalStateException("해당 아이디와 비밀번호를 가진 회원을 찾을 수 없습니다."));
+
+        // JWT 토큰 발급 및 RefreshToken 엔티티 값 갱신
+        String accessTokenValue = tokenProvider.createToken(user, TokenType.ACCESS);
+        String refreshTokenValue = tokenProvider.createToken(user, TokenType.REFRESH);
+        user.getRefreshToken().setTokenValue(refreshTokenValue);
+
+        // TokenResponseDto를 반환
+        return TokenResponseDto.builder()
+                .accessToken(accessTokenValue)
+                .refreshToken(refreshTokenValue)
+                .build();
+    }
+
+    public String getGoogleRedirectUrl() {
+        log.info("AuthorizationService.getGoogleAuthorizationRedirect() called");
+
+        StringBuilder url = new StringBuilder();
+        url.append("https://accounts.google.com/o/oauth2/v2/auth?client_id=")
+                .append(GOOGLE_CLIENT_ID)
+                .append("&redirect_uri=")
+                .append(GOOGLE_REDIRECT_URI)
+                .append("&response_type=code&scope=https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email");
+
+        return url.toString();
+    }
+
+    public String getGoogleAccessToken(String code) {
+        log.info("AuthorizationService.getGoogleAccessToken() called");
+
+        RestTemplate restTemplate = new RestTemplate();
+        Map<String, String> params = Map.of(
+                "code", code,
+                "scope", "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email",
+                "client_id", GOOGLE_CLIENT_ID,
+                "client_secret", GOOGLE_CLIENT_SECRET,
+                "redirect_uri", GOOGLE_REDIRECT_URI,
+                "grant_type", "authorization_code"
+        );
+
+        ResponseEntity<String> responseEntity = restTemplate.postForEntity(GOOGLE_TOKEN_URL, params, String.class);
+
+        if (responseEntity.getStatusCode().is2xxSuccessful()) {
+            String json = responseEntity.getBody();
+            Gson gson = new Gson();
+
+            return gson.fromJson(json, GoogleAccessTokenDto.class)
+                    .getAccessToken();
+        }
+
+        throw new RuntimeException("구글 엑세스 토큰 획득 실패");
+    }
+
+    public TokenResponseDto googleSignUpOrSignIn(String googleAccessToken) {
+        log.info("AuthorizationService.googleSignUpOrSignIn() called");
+
+        GoogleUserInfoDto googleUserInfo = getGoogleUserInfo(googleAccessToken);
+
+        // 유효성 검사
+        if (!googleUserInfo.getVerifiedEmail()) {
+            throw new IllegalStateException("이메일 인증이 되지 않은 유저입니다.");
+        }
+
+        // 기존에 회원가입 하지 않은 회원이라면 회원가입함
+        User user = userRepository.findByGoogleIdentifier(googleUserInfo.getId())
+                .orElseGet(() -> userRepository.save(GoogleUser.builder()
+                        .googleIdentifier(googleUserInfo.getId())
+                        .email(googleUserInfo.getEmail())
+                        .name(googleUserInfo.getName())
+                        .profileUrl(googleUserInfo.getPictureUrl())
+                        .build())
+                );
+
+        // JWT 토큰 생성 및 RefreshToken 엔티티 값 수정
+        String accessTokenValue = tokenProvider.createToken(user, TokenType.ACCESS);
+        String refreshTokenValue = tokenProvider.createToken(user, TokenType.REFRESH);
+        user.getRefreshToken().setTokenValue(refreshTokenValue);
+
+        // TokenResponseDto 반환
+        return TokenResponseDto.builder()
+                .accessToken(accessTokenValue)
+                .refreshToken(refreshTokenValue)
+                .build();
+    }
+
+    private GoogleUserInfoDto getGoogleUserInfo(String accessToken) {
+        log.info("AuthorizationService.getGoogleUserInfo() called");
+
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "https://www.googleapis.com/oauth2/v2/userinfo?access_token=" + accessToken;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        RequestEntity<Void> requestEntity = new RequestEntity<>(headers, HttpMethod.GET, URI.create(url));
+        ResponseEntity<String> responseEntity = restTemplate.exchange(requestEntity, String.class);
+
+        if (responseEntity.getStatusCode().is2xxSuccessful()) {
+            String json = responseEntity.getBody();
+            Gson gson = new Gson();
+            return gson.fromJson(json, GoogleUserInfoDto.class);
+        }
+
+        throw new RuntimeException("구글 유저 정보 획득 실패");
+    }
+
+    public String getKakaoRedirectUrl() {
+        log.info("AuthorizationService.getKakaoRedirectUrl() called");
+
+        StringBuilder url = new StringBuilder();
+        url.append("https://kauth.kakao.com/oauth/authorize?")
+                .append("client_id=")
+                .append(KAKAO_CLIENT_ID)
+                .append("&redirect_uri=")
+                .append(KAKAO_REDIRECT_URL)
+                .append("&response_type=code")
+                .append("&scope=profile_nickname,profile_image,account_email");
+
+        return url.toString();
+    }
+
+    public String getKakaoAccessToken(String code) {
+        log.info("AuthorizationService.getKakaoAccessToken() called");
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 메시지 header 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // 메시지 body 설정
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", KAKAO_CLIENT_ID);
+        params.add("redirect_uri", KAKAO_REDIRECT_URL);
+        params.add("client_secret", KAKAO_CLIENT_SECRET);
+
+        // POST 요청 전송
+        HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(params, headers);
+        ResponseEntity<String> responseEntity = restTemplate.exchange(KAKAO_TOKEN_URL, HttpMethod.POST, httpEntity, String.class);
+
+        if (responseEntity.getStatusCode().is2xxSuccessful()) {
+            String json = responseEntity.getBody();
+            Gson gson = new Gson();
+
+            return gson.fromJson(json, KakaoAccessTokenDto.class)
+                    .getAccessToken();
+        }
+
+        throw new RuntimeException("카카오 엑세스 토큰 획득 실패");
+    }
+
+    public TokenResponseDto kakaoSignUpOrSignIn(String kakaoAccessToken) {
+        log.info("AuthorizationService.kakaoSignUpOrSignIn() called");
+
+        KaKaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(kakaoAccessToken);
+
+        // 유효성 검사
+        if (!kakaoUserInfo.isValidatedEmail()) {
+            throw new IllegalStateException("이메일 인증이 되지 않은 유저입니다.");
+        }
+
+        // 기존에 회원가입 하지 않은 회원이라면 회원가입함
+        User user = userRepository.findByKakaoIdentifier(kakaoUserInfo.getId())
+                .orElseGet(() -> userRepository.save(KakaoUser.builder()
+                        .kakaoIdentifier(kakaoUserInfo.getId())
+                        .email(kakaoUserInfo.getEmail())
+                        .name(kakaoUserInfo.getName())
+                        .profileUrl(kakaoUserInfo.getProfileUrl())
+                        .build())
+                );
+
+        // JWT 토큰 생성 및 RefreshToken 엔티티 값 수정
+        String accessTokenValue = tokenProvider.createToken(user, TokenType.ACCESS);
+        String refreshTokenValue = tokenProvider.createToken(user, TokenType.REFRESH);
+        user.getRefreshToken().setTokenValue(refreshTokenValue);
+
+        // TokenResponseDto 반환
+        return TokenResponseDto.builder()
+                .accessToken(accessTokenValue)
+                .refreshToken(refreshTokenValue)
+                .build();
+    }
+
+    private KaKaoUserInfoDto getKakaoUserInfo(String accessToken) {
+        log.info("AuthorizationService.getKakaoUserInfo() called");
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> responseEntity = restTemplate.exchange(KAKAO_USER_INFO_URL, HttpMethod.GET, httpEntity, String.class);
+
+        if (responseEntity.getStatusCode().is2xxSuccessful()) {
+            String json = responseEntity.getBody();
+            Gson gson = new Gson();
+            return gson.fromJson(json, KaKaoUserInfoDto.class);
+        }
+
+        throw new RuntimeException("카카오 유저 정보 획득 실패");
+    }
+}

--- a/src/main/java/success/planfit/service/AuthorizationService.java
+++ b/src/main/java/success/planfit/service/AuthorizationService.java
@@ -306,4 +306,16 @@ public class AuthorizationService {
 
         throw new RuntimeException("카카오 유저 정보 획득 실패");
     }
+
+    public void invalidateRefreshToken(User user) {
+        log.info("AuthorizationService.invalidateRefreshToken() called");
+
+        user.getRefreshToken().setTokenValue(null);
+    }
+
+    public void deleteUser(User user) {
+        log.info("AuthorizationService.removeUser() called");
+
+        userRepository.delete(user);
+    }
 }

--- a/src/main/java/success/planfit/service/UserService.java
+++ b/src/main/java/success/planfit/service/UserService.java
@@ -1,0 +1,25 @@
+package success.planfit.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import success.planfit.domain.user.User;
+import success.planfit.repository.UserRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User findById(Long id) {
+        log.info("UserService.findById() called");
+
+        return userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id로 회원이 조회되지 않음."));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,13 @@ keys:
   jwt:
     secret: ${JWT_SECRET}
     access-token-validity-in-milliseconds: ${JWT_ACCESS_TOKEN_VALIDITY_IN_MILLISECONDS}
-  google-places:
-    key: ${GOOGLE_PLACES_API_KEY}
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
+    places:
+      key: ${GOOGLE_PLACES_API_KEY}
   kakao:
     rest-api-key: ${KAKAO_REST_API_KEY}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+    client-secret: ${KAKAO_CLIENT_SECRET}

--- a/src/test/java/success/planfit/domain/user/UserTest.java
+++ b/src/test/java/success/planfit/domain/user/UserTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @SpringBootTest
@@ -25,7 +26,6 @@ class UserTest {
                 .googleIdentifier("helloGoogle")
                 .name("googleUserA")
                 .phoneNumber("01011112222")
-                .birthOfDate(LocalDateTime.now())
                 .identity(IdentityType.STUDENT)
                 .email("googleUser@gmail.com")
                 .profileUrl("helloProfileUrl")
@@ -47,7 +47,7 @@ class UserTest {
                 .kakaoIdentifier(123L)
                 .name("kakaoUserA")
                 .phoneNumber("01011112222")
-                .birthOfDate(LocalDateTime.now())
+                .birthOfDate(LocalDate.now())
                 .identity(IdentityType.STUDENT)
                 .email("kakaoUser@kakao.com")
                 .profileUrl("helloProfileUrl")
@@ -70,7 +70,7 @@ class UserTest {
                 .password("helloPassword")
                 .name("planFitUserA")
                 .phoneNumber("01011112222")
-                .birthOfDate(LocalDateTime.now())
+                .birthOfDate(LocalDate.now())
                 .identity(IdentityType.STUDENT)
                 .email("planFitUser@planfit.com")
                 .profileUrl("helloProfileUrl")


### PR DESCRIPTION
# Pull Request
<!--
    템플릿을 크게 어기지 않는 선에서 자유롭게 작성해 주세요!
-->

---

## 작업 내용 (What)
<!-- 
    여기에 작업한 내용을 간략히 작성해주세요.
        예: 새로운 API 엔드포인트 추가 
-->
 - JWT를 이용한 인증/인가 로직을 구현했습니다.
 - 플랜핏 자체 회원가입/로그인을 구현했습니다.
 - 구글 회원가입/로그인을 구현했습니다.
 - 카카오 회원가입/로그인을 구현했습니다.
 - 회원 탈퇴 기능을 구현했습니다.<br>(`orphanRemoval = true` 사용 여부를 결정한 뒤 메서드를 추가로 개선해야 합니다)
 - 리프레시 토큰 무효화 기능을 구현했습니다.
 - 엑세스 토큰 재발급 기능을 구현했습니다.
 - `/authorization` 하위 경로를 제외한 모든 API 요청은 `access token`을 `Authorization` 헤더에 담아야 하도록 만들었습니다.
 - `application.yml`에 구글, 카카오 API와 관련된 환경변수를 추가했습니다.<br>(값은 노션 참고)
 - `User` 엔티티의 `DiscriminatorColumn`의 `name` 속성을 삭제했습니다.<br>(이유는 하단 참고)
 - `User` 엔티티와 `RefreshToken` 엔티티 간의 연관 관계를 수정했습니다.
 - `User` 엔티티 생성시 연관된 `RefreshToken` 엔티티를 자동으로 생성하도록 생성자를 수정했습니다.<br>(이유는 하단 참고)
 - `RefreshToken` 엔티티의 `tokenValue` 필드에 `Setter`를 추가했습니다.
 - `User` 엔티티의 `birthOfDate` 필드의 자료형을 `LocalDateTime`에서 `LocalDate`로 수정했습니다.
 - `User` 엔티티의 일부 필드에 `nullable = false` 속성을 제거했습니다.(이유는 하단 참고)

## 작업 이유 (Why)
<!--
    작업을 진행한 이유를 명확히 설명해주세요.
        예: 성능 개선
        예: 특정 버그 해결
-->
 - `User` 엔티티와 `RefreshToken` 엔티티 간의 관계 수정
   - 외래키가 소속된 테이블이 `user` 테이블로 변경되었음을 반영하기 위해 연관 필드를 `User` 엔티티로 이동시켰습니다.
   - `RefreshToken` 엔티티는 오직 `User` 엔티티를 통해서만 관리되므로, `cascade`와 `orphanRemoval`을 적용했습니다.
   - 모든 회원은 최초 생성시에 `RefershToken`을 지니게 되므로, `User` 엔티티의 생성자를 통해 연관된 `RefreshToken`을 자동으로 생성하게 함으로써 `RefreshToken` 엔티티를 별도로 생성하지 않아도 되게 했습니다.
 - `@DiscriminatorColumn`의 `name` 속성 제거
   - 현재 `@DiscriminatorValue` 애노태이션을 사용하고 있지 않으므로, 해당 컬럼의 값은 `KakaoUser`, `GoogleUser`, `PlanfitUser`가 됩니다.
   - 그러므로 기존의 `authorized_by`보다 `dtype`이 더 자연스러운 이름이라고 판단되어, 관례에 따라 JPA가 제공하는 기본값을 사용할 수 있도록 `name` 속성을 제거했습니다.
 - `User` 테이블 필드의 `nullable = false` 제거
   - 현재 저희가 이용할 수 있는 카카오 API, 구글 API에 따르면 `User` 엔티티의 일부 필드 값을 회원가입 시점에 가져올 수 없는 것이 확인되었습니다.
   - 별도의 기본값을 지정하는 것 보다 `null` 값을 가지도록 하는 것이 바람직하다 생각해, 우선 `nullable = false`를 제거하여 `null` 값을 허용하도록 수정했습니다.

## 코드 리뷰 시 중점적으로 보면 좋은 내용 (Focus Areas)
<!--
    리뷰어가 중점적으로 봐야 할 부분이나 의논이 필요한 부분을 작성해주세요.
        예: 특정 함수의 동작 방식에 대한 의견
        예: 성능 개선을 위해 다른 접근 방식이 있는지
        예: 코드 스타일에 대한 의견
-->
 - JWT 발급의 핵심이 되는 클래스들은 `jwt` 패키지 안에 위치시켜 두었습니다.
 - 유저 회원가입/로그인과 관련이 되는 기능은 `AuthorizationController`와 `AuthorizationService` 클래스가 지니도록 했습니다.
 - `User` - `RefreshToken` 엔티티 말고도, 똑같이 한 부모 엔티티에 의해서만 관리되는 엔티티 관계들이 있습니다.<br>해당 엔티티 관계에 `cascade = CascadeType.ALL`과 `orphanRemoval = true`를 적용하는 것이 어떤지 의견을 구하고 싶습니다.<br>해당 속성들을 적용하면 다음과 같은 이점을 얻을 수 있습니다.
   1. 부모 엔티티만 영속화해도 자식 엔티티들이 자동으로 영속화되니 간편합니다.
   2. 부모 엔티티만 삭제해도 자식 엔티티들이 자동으로 삭제되니 간편합니다.
			(현재 상황에서는 부모 엔티티를 삭제하기 위해서는 우선적으로 자식 엔티티들을 모두 삭제해야 하는 번거로움이 있습니다)
   3. 부모 엔티티에 대해서만 `Repository`를 만들고, 자식 엔티티는 `EntityManager`를 사용하지 않는 `DAO` 클래스만 작성해도 됩니다.(혹은 아예 작성할 필요가 없어집니다)
 - `@Slf4j`를 이용해 각 메서드 호출시마다 로그를 띄우도록 작업했습니다. 로깅에 대한 좋은 의견이 있는 분이 계시면 공유해 주신다면 감사하겠습니다.

---

### 체크리스트
- [x] 코드가 올바르게 작동하며 기존 기능에 영향을 미치지 않는지 확인했습니다.
- [x] 테스트를 추가하거나 기존 테스트가 통과하는지 확인했습니다.
- [x] 리뷰어에게 필요한 정보를 모두 제공했습니다.
