### PR TITLE
chore: 플랜핏 회원 가입 시, 사진 데이터를 URL과 바이너리 데이터 중 선택할 수 있도록 함

### DIFF
--- a/src/main/java/success/planfit/dto/request/PlanFitUserSignUpRequestDto.java
+++ b/src/main/java/success/planfit/dto/request/PlanFitUserSignUpRequestDto.java
@@ -5,6 +5,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import success.planfit.domain.user.IdentityType;
 import success.planfit.domain.user.PlanfitUser;
 import success.planfit.photo.PhotoProvider;
+import success.planfit.photo.PhotoType;
 
 import java.time.LocalDate;
 
@@ -19,9 +20,17 @@ public class PlanFitUserSignUpRequestDto {
     private LocalDate birthOfDate;
     private IdentityType identity;
     private String email;
-    private String profileUrl;
+    private String profilePhoto;
+    private PhotoType photoType;
 
     public PlanfitUser toEntity() {
+
+        byte[] photo = switch (photoType) {
+            case URL -> PhotoProvider.getImageFromUrl(profilePhoto);
+            case ENCODED_BINARY -> PhotoProvider.decode(profilePhoto);
+            default -> null;
+        };
+
         return PlanfitUser.builder()
                 .name(name)
                 .loginId(loginId)
@@ -30,7 +39,7 @@ public class PlanFitUserSignUpRequestDto {
                 .birthOfDate(birthOfDate)
                 .identity(identity)
                 .email(email)
-                .profilePhoto(PhotoProvider.getImageFromUrl(profileUrl))
+                .profilePhoto(photo)
                 .build();
     }
 }

--- a/src/main/java/success/planfit/photo/PhotoType.java
+++ b/src/main/java/success/planfit/photo/PhotoType.java
@@ -1,0 +1,5 @@
+package success.planfit.photo;
+
+public enum PhotoType {
+    URL, ENCODED_BINARY
+}


### PR DESCRIPTION
# Pull Request
<!--
    템플릿을 크게 어기지 않는 선에서 자유롭게 작성해 주세요!
-->

---

## 작업 내용 (What)
<!-- 
    여기에 작업한 내용을 간략히 작성해주세요.
        예: 새로운 API 엔드포인트 추가 
-->
 - 사진 데이터의 종류(URL, 인코딩된 바이너리 데이터)를 명시할 `PhotoType` 클래스를 추가했습니다.
 - `PlanFitUserSignUpRequestDto`에 기존에 존재하던 `profileUrl` 필드의 이름을 profilePhoto로 변경했습니다.
 - `PlanFitUserSignUpRequestDto`에 `PhotoType photoType` 필드를 추가했습니다.
 - `PlanFitUserSignUpRequestDto`의 `toEntity()` 메서드를, 사진 타입에 맞게 User 엔티티에 적절한 값이 들어가도록 개선했습니다.

## 작업 이유 (Why)
<!--
    작업을 진행한 이유를 명확히 설명해주세요.
        예: 성능 개선
        예: 특정 버그 해결
-->
 - 클라이언트 측에서 사진 데이터를 URL로 보내줄지 인코딩된 바이너리 데이터로 보내줄지 확정되지 않아, 어느 형태로 보내주던 상관없이 요청을 처리할 수 있도록 개선했습니다.

## 코드 리뷰 시 중점적으로 보면 좋은 내용 (Focus Areas)
<!--
    리뷰어가 중점적으로 봐야 할 부분이나 의논이 필요한 부분을 작성해주세요.
        예: 특정 함수의 동작 방식에 대한 의견
        예: 성능 개선을 위해 다른 접근 방식이 있는지
        예: 코드 스타일에 대한 의견
-->
 - 플랜핏 회원 가입을 위한 DTO가 수정되었으니, 회원가입 기능을 사용해 테스트 하실 때 참고하시면 좋을 것 같습니다.
 - 관련된 API 명세서도 수정할 예정입니다.

---

### 체크리스트
- [x] 코드가 올바르게 작동하며 기존 기능에 영향을 미치지 않는지 확인했습니다.
- [x] 테스트를 추가하거나 기존 테스트가 통과하는지 확인했습니다.
- [x] 리뷰어에게 필요한 정보를 모두 제공했습니다.
