### PR TITLE
fix: 엔티티 삭제가 불가능하던 문제 해결

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
-      <profile default="true" name="Default" enabled="true" />
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">

--- a/src/main/java/success/planfit/domain/user/GoogleUser.java
+++ b/src/main/java/success/planfit/domain/user/GoogleUser.java
@@ -1,6 +1,7 @@
 package success.planfit.domain.user;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +13,6 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @Entity
 public class GoogleUser extends User {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @Column(nullable = false, unique = true)
     private String googleIdentifier;

--- a/src/main/java/success/planfit/domain/user/KakaoUser.java
+++ b/src/main/java/success/planfit/domain/user/KakaoUser.java
@@ -1,7 +1,8 @@
 package success.planfit.domain.user;
 
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +13,6 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @Entity
 public class KakaoUser extends User {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @Column(nullable = false, unique = true)
     private Long kakaoIdentifier;

--- a/src/main/java/success/planfit/domain/user/PlanfitUser.java
+++ b/src/main/java/success/planfit/domain/user/PlanfitUser.java
@@ -1,7 +1,8 @@
 package success.planfit.domain.user;
 
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,10 +14,6 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @Entity
 public class PlanfitUser extends User {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @Column(nullable = false, unique = true)
     private String loginId;

--- a/src/main/java/success/planfit/service/AuthorizationService.java
+++ b/src/main/java/success/planfit/service/AuthorizationService.java
@@ -320,7 +320,7 @@ public class AuthorizationService {
     }
 
     public void deleteUser(Long userId) {
-        log.info("AuthorizationService.removeUser() called");
+        log.info("AuthorizationService.deleteUser() called");
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("ID를 통해 유저 조회 실패"));


### PR DESCRIPTION
# Pull Request
<!--
    템플릿을 크게 어기지 않는 선에서 자유롭게 작성해 주세요!
-->

---

## 작업 내용 (What)
<!-- 
    여기에 작업한 내용을 간략히 작성해주세요.
        예: 새로운 API 엔드포인트 추가 
-->
 - User 엔티티의 하위 클래스에 있던 `id` 필드를 삭제했습니다.
 - 추가로, `AuthorizationService`에 있는 부적절한 로그 메시지를 수정했습니다.

## 작업 이유 (Why)
<!--
    작업을 진행한 이유를 명확히 설명해주세요.
        예: 성능 개선
        예: 특정 버그 해결
-->
 - `User`와 그 하위 클래스들은 연관 엔티티가 아닌 상속 관계로 구현되어 있는데, 부모-자식 클래스 모두에 PK 필드가 있어 `orphanRemoval`의 오작동이 발생했습니다.

## 코드 리뷰 시 중점적으로 보면 좋은 내용 (Focus Areas)
<!--
    리뷰어가 중점적으로 봐야 할 부분이나 의논이 필요한 부분을 작성해주세요.
        예: 특정 함수의 동작 방식에 대한 의견
        예: 성능 개선을 위해 다른 접근 방식이 있는지
        예: 코드 스타일에 대한 의견
-->
 - JPA 내부 동작 도중 문제가 발생하는 것이라 디버깅이 매우 힘들었습니다. 이번 케이스를 꼭 참고하시고 이후에 같은 문제가 발생했을 때 쉽게 해결하시기 바랍니다.

---

### 체크리스트
- [x] 코드가 올바르게 작동하며 기존 기능에 영향을 미치지 않는지 확인했습니다.
- [x] 테스트를 추가하거나 기존 테스트가 통과하는지 확인했습니다.
- [x] 리뷰어에게 필요한 정보를 모두 제공했습니다.
